### PR TITLE
Extend portless protocol support in 1:1 share ratio

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -620,9 +620,7 @@ int xlate_map_v4_to_v6(nat46_instance_t *nat46, nat46_xlate_rule_t *rule, void *
 }
 
 int xlate_map_v6_to_v4(nat46_instance_t *nat46, nat46_xlate_rule_t *rule, void *pipv6, void *pipv4, int version) {
-  uint8_t psid_bits_len;
   uint8_t v4_lsb_bits_len = 32 - rule->v4_pref_len;
-
 
   if (memcmp(pipv6, &rule->v6_pref, rule->v6_pref_len/8)) {
     /* address not within the MAP IPv6 prefix */
@@ -644,7 +642,6 @@ int xlate_map_v6_to_v4(nat46_instance_t *nat46, nat46_xlate_rule_t *rule, void *
     nat46debug(0, "xlate_map_v6_to_v4: rule->ea_len < (32 - rule->v4_pref_len)");
     return 0;
   }
-  psid_bits_len = rule->ea_len - (32 - rule->v4_pref_len);
 
   memcpy(pipv4, &rule->v4_pref, 4);
   if (v4_lsb_bits_len) {


### PR DESCRIPTION
Commit 5fed76d added support for portless protocol in 1:1 share ratio but it only considered the IPv4 prefix length to check the 1:1 share ratio which is too restrictive as one MAP domain needs to be assigned per CE.
Therefore take also the assigned EA bits length into account by verifying if all EA bits are used to generate the IPv4 address in combination with the IPv4 prefix length which will make the 1:1 sharing ratio more scalable.