### PR TITLE
nat46-core: fix compilation with kernel 5.4

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -17,6 +17,7 @@
  */
 
 #include <net/route.h>
+#include <linux/version.h>
 
 #include "nat46-glue.h"
 #include "nat46-core.h"
@@ -1601,7 +1602,11 @@ void nat46_ipv6_input(struct sk_buff *old_skb) {
   /* Remove any debris in the socket control block */
   memset(IPCB(new_skb), 0, sizeof(struct inet_skb_parm));
   /* Remove netfilter references to IPv6 packet, new netfilter references will be created based on IPv4 packet */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0)
   nf_reset(new_skb);
+#else
+  nf_reset_ct(new_skb);
+#endif
 
   /* modify packet: actual IPv6->IPv4 transformation */
   truncSize = v6packet_l3size - sizeof(struct iphdr); /* chop first 20 bytes */
@@ -1806,7 +1811,11 @@ void nat46_ipv4_input(struct sk_buff *old_skb) {
   /* Remove any debris in the socket control block */
   memset(IPCB(new_skb), 0, sizeof(struct inet_skb_parm));
   /* Remove netfilter references to IPv4 packet, new netfilter references will be created based on IPv6 packet */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0)
   nf_reset(new_skb);
+#else
+  nf_reset_ct(new_skb);
+#endif
 
   /* expand header (add 20 extra bytes at the beginning of sk_buff) */
   pskb_expand_head(new_skb, IPV6V4HDRDELTA + (add_frag_header?8:0), 0, GFP_ATOMIC);


### PR DESCRIPTION
nf_reset() was renamed to nf_reset_ct() in upstream Linux commit 895b5c9f206e ("netfilter: drop bridge nf reset from nf_reset)"