### PR TITLE
nat46-module: fix compilation with kernel 5.6

### DIFF
--- a/nat46/modules/nat46-module.c
+++ b/nat46/modules/nat46-module.c
@@ -15,6 +15,7 @@
  *
  */
 
+#include <linux/version.h>
 #include <linux/module.h>
 #include <linux/kernel.h>
 #include <linux/init.h>
@@ -136,6 +137,7 @@ static ssize_t nat46_proc_write(struct file *file, const char __user *buffer,
 	return count;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0)
 static const struct file_operations nat46_proc_fops = {
 	.owner		= THIS_MODULE,
 	.open		= nat46_proc_open,
@@ -144,6 +146,15 @@ static const struct file_operations nat46_proc_fops = {
 	.release	= single_release,
 	.write		= nat46_proc_write,
 };
+#else
+static const struct proc_ops nat46_proc_fops = {
+	.proc_open	= nat46_proc_open,
+	.proc_read	= seq_read,
+	.proc_lseek	= seq_lseek,
+	.proc_release	= single_release,
+	.proc_write	= nat46_proc_write,
+};
+#endif
 
 
 int create_nat46_proc_entry(void) {


### PR DESCRIPTION
proc_create() now takes a struc proc_ops instead of a struct
file_operations. Fortunately the member functions of both these structs
have the same prototypes so we can just define nat46_proc_fops
differently for newer kernels.

Fixes #13

Signed-off-by: Chris Packham <chris.packham@alliedtelesis.co.nz>