### PR TITLE
Zero checksum

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1576,6 +1576,7 @@ void nat46_ipv6_input(struct sk_buff *old_skb) {
         }
       case NEXTHDR_UDP: {
         struct udphdr *udp = add_offset(ip6h, v6packet_l3size);
+        u16 sum1, sum2;
         if ((udp->check == 0) && zero_csum_pass) {
           /* zero checksum and the config to pass it is set - do nothing with it */
           break;

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1576,6 +1576,10 @@ void nat46_ipv6_input(struct sk_buff *old_skb) {
         }
       case NEXTHDR_UDP: {
         struct udphdr *udp = add_offset(ip6h, v6packet_l3size);
+        if ((udp->check == 0) && zero_csum_pass) {
+          /* zero checksum and the config to pass it is set - do nothing with it */
+          break;
+        }
         u16 sum1 = csum_ipv6_unmagic(nat46, &ip6h->saddr, &ip6h->daddr, l3_infrag_payload_len, NEXTHDR_UDP, udp->check);
         u16 sum2 = csum_tcpudp_remagic(v4saddr, v4daddr, l3_infrag_payload_len, NEXTHDR_UDP, sum1);
         udp->check = sum2;


### PR DESCRIPTION
Declare before assignment to avoid "error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]"

See: https://github.com/ayourtch/nat46/commit/7688102dce352d149da72d874df36c6d5fcf7be3