### PR TITLE
Avoid "ISO C90 forbids mixed declarations and code" warning.

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1576,6 +1576,7 @@ void nat46_ipv6_input(struct sk_buff *old_skb) {
         }
       case NEXTHDR_UDP: {
         struct udphdr *udp = add_offset(ip6h, v6packet_l3size);
+        u16 sum1, sum2;
         if ((udp->check == 0) && zero_csum_pass) {
           /* zero checksum and the config to pass it is set - do nothing with it */
           break;

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1581,8 +1581,8 @@ void nat46_ipv6_input(struct sk_buff *old_skb) {
           /* zero checksum and the config to pass it is set - do nothing with it */
           break;
         }
-        u16 sum1 = csum_ipv6_unmagic(nat46, &ip6h->saddr, &ip6h->daddr, l3_infrag_payload_len, NEXTHDR_UDP, udp->check);
-        u16 sum2 = csum_tcpudp_remagic(v4saddr, v4daddr, l3_infrag_payload_len, NEXTHDR_UDP, sum1);
+        sum1 = csum_ipv6_unmagic(nat46, &ip6h->saddr, &ip6h->daddr, l3_infrag_payload_len, NEXTHDR_UDP, udp->check);
+        sum2 = csum_tcpudp_remagic(v4saddr, v4daddr, l3_infrag_payload_len, NEXTHDR_UDP, sum1);
         udp->check = sum2;
         break;
         }


### PR DESCRIPTION
ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]

Unrelated error when test compiling:

> ~/nat46/nat46/modules$ KCPPFLAGS='-DNAT46_VERSION=\"test\" -Werror' make
> make -C /lib/modules/5.8.0-48-generic/build M=/home/detonate/nat46/nat46/modules modules
> make[1]: Entering directory '/usr/src/linux-headers-5.8.0-48-generic'
>   CC [M]  /home/detonate/nat46/nat46/modules/nat46-netdev.o
> /home/detonate/nat46/nat46/modules/nat46-netdev.c: In function ‘nat46_remove’:
> /home/detonate/nat46/nat46/modules/nat46-netdev.c:257:2: error: ISO C90 forbids variable length array ‘config_remove’ [-Werror=vla]
>   257 |  char config_remove[buflen];
>       |  ^~~~
> /home/detonate/nat46/nat46/modules/nat46-netdev.c:277:3: error: ISO C90 forbids variable length array ‘config’ [-Werror=vla]
>   277 |   char config[buflen];
>       |   ^~~~
> cc1: all warnings being treated as errors

But compiles ignoring that:

> /nat46/nat46/modules$ KCPPFLAGS='-DNAT46_VERSION=\"test\"' make
> make -C /lib/modules/5.8.0-48-generic/build M=/home/detonate/nat46/nat46/modules modules
> make[1]: Entering directory '/usr/src/linux-headers-5.8.0-48-generic'
>   CC [M]  /home/detonate/nat46/nat46/modules/nat46-netdev.o
> /home/detonate/nat46/nat46/modules/nat46-netdev.c: In function ‘nat46_remove’:
> /home/detonate/nat46/nat46/modules/nat46-netdev.c:257:2: warning: ISO C90 forbids variable length array ‘config_remove’ [-Wvla]
>   257 |  char config_remove[buflen];
>       |  ^~~~
> /home/detonate/nat46/nat46/modules/nat46-netdev.c:277:3: warning: ISO C90 forbids variable length array ‘config’ [-Wvla]
>   277 |   char config[buflen];
>       |   ^~~~
>   CC [M]  /home/detonate/nat46/nat46/modules/nat46-module.o
>   CC [M]  /home/detonate/nat46/nat46/modules/nat46-core.o
>   CC [M]  /home/detonate/nat46/nat46/modules/nat46-glue.o
>   LD [M]  /home/detonate/nat46/nat46/modules/nat46.o
>   MODPOST /home/detonate/nat46/nat46/modules/Module.symvers
>   CC [M]  /home/detonate/nat46/nat46/modules/nat46.mod.o
>   LD [M]  /home/detonate/nat46/nat46/modules/nat46.ko
> make[1]: Leaving directory '/usr/src/linux-headers-5.8.0-48-generic'
