### PR TITLE
fix memory leak in nat46_netdev_destroy().The netdev is forgotten to free in nat46_netdev_destroy function

### DIFF
--- a/nat46/modules/nat46-netdev.c
+++ b/nat46/modules/nat46-netdev.c
@@ -169,6 +169,7 @@ void nat46_netdev_destroy(struct net_device *dev)
 {
 	netdev_nat46_set_instance(dev, NULL);
 	unregister_netdev(dev);
+	free_netdev(dev);
 	printk("nat46: Destroying nat46 device.\n");
 }
 


### PR DESCRIPTION
fix memory leak in nat46_netdev_destroy().The netdev is forgotten to free in nat46_netdev_destroy function

BUG: memory leak
unreferenced object 0xffffffc0464c0000 (size 1024):
  comm "464xlatcfg", pid 18029, jiffies 4294952244 (age 10197.930s)
  hex dump (first 32 bytes):
    00 00 f6 4e c0 ff ff ff 00 0c fb 00 c0 ff ff ff  ...N............
    00 0c fb 00 c0 ff ff ff 00 00 00 00 00 00 00 00  ................
  backtrace:
    [<ffffffc000184848>] __save_stack_trace+0x24/0x30
    [<ffffffc0001850a8>] create_object+0x1fc/0x384
    [<ffffffc00082c6e4>] kmemleak_alloc+0x80/0xb4
    [<ffffffc000176bdc>] __kmalloc+0x1d8/0x250
    [<ffffffc0006b5424>] alloc_netdev_mqs+0x2f8/0x4b8
    [<ffffffbffce107f0>] nat46_netdev_create+0xe0/0x1b8 [nat46]
    [<ffffffbffce10990>] nat46_create+0x40/0x58 [nat46]
    [<ffffffbffce10fb8>] nat46_destroy_all+0x2a8/0x3b8 [nat46]
    [<ffffffc0001ee38c>] proc_reg_write+0xb8/0xe8
    [<ffffffc000189920>] do_loop_readv_writev+0xac/0xf8
    [<ffffffc00018a258>] do_readv_writev+0x120/0x23c
    [<ffffffc00018a42c>] vfs_writev+0x54/0x64
    [<ffffffc00018b038>] SyS_writev+0x58/0xac
    [<ffffffc000085db0>] el0_svc_naked+0x24/0x28
    [<ffffffffffffffff>] 0xffffffffffffffff