### PR TITLE
add the mutex lock for create/delete/config/insert nat46 devices to fix nat46 module crash issues.

### DIFF
--- a/nat46/modules/nat46-glue.c
+++ b/nat46/modules/nat46-glue.c
@@ -18,6 +18,7 @@
 #include "nat46-glue.h"
 #include "nat46-core.h"
 
+static DEFINE_MUTEX(ref_lock);
 int is_valid_nat46(nat46_instance_t *nat46) {
   return (nat46 && (nat46->sig == NAT46_SIGNATURE));
 }
@@ -49,20 +50,25 @@ nat46_instance_t *alloc_nat46_instance(int npairs, nat46_instance_t *old, int fr
 
 nat46_instance_t *get_nat46_instance(struct sk_buff *sk) {
   nat46_instance_t *nat46 = netdev_nat46_instance(sk->dev);
+  mutex_lock(&ref_lock);
   if (is_valid_nat46(nat46)) {
     nat46->refcount++;
+    mutex_unlock(&ref_lock);
     return nat46;
   } else {
     printk("[nat46] get_nat46_instance: Could not find a valid NAT46 instance!");
+    mutex_unlock(&ref_lock);
     return NULL;
   }
 }
 
 void release_nat46_instance(nat46_instance_t *nat46) {
+  mutex_lock(&ref_lock);
   nat46->refcount--;
   if(0 == nat46->refcount) {
     printk("[nat46] release_nat46_instance: freeing nat46 instance with %d pairs\n", nat46->npairs);
     nat46->sig = FREED_NAT46_SIGNATURE;
     kfree(nat46);
   }
+  mutex_unlock(&ref_lock);
 }

--- a/nat46/modules/nat46-module.c
+++ b/nat46/modules/nat46-module.c
@@ -64,6 +64,8 @@ MODULE_PARM_DESC(debug, "debugging messages level (default=1)");
 module_param(zero_csum_pass, int, 0);
 MODULE_PARM_DESC(zero_csum_pass, "pass all-zero checksum unchanged (default=0)");
 
+static DEFINE_MUTEX(add_del_lock);
+
 static struct proc_dir_entry *nat46_proc_entry;
 static struct proc_dir_entry *nat46_proc_parent;
 
@@ -118,23 +120,33 @@ static ssize_t nat46_proc_write(struct file *file, const char __user *buffer,
 		if (0 == strcmp(arg_name, "add")) {
 			devname = get_devname(&tail);
 			printk(KERN_INFO "nat46: adding device (%s)\n", devname);
+			mutex_lock(&add_del_lock);
 			nat46_create(devname);
+			mutex_unlock(&add_del_lock);
 		} else if (0 == strcmp(arg_name, "del")) {
 			devname = get_devname(&tail);
 			printk(KERN_INFO "nat46: deleting device (%s)\n", devname);
+			mutex_lock(&add_del_lock);
 			nat46_destroy(devname);
+			mutex_unlock(&add_del_lock);
 		} else if (0 == strcmp(arg_name, "config")) {
 			devname = get_devname(&tail);
 			printk(KERN_INFO "nat46: configure device (%s) with '%s'\n", devname, tail);
+			mutex_lock(&add_del_lock);
 			nat46_configure(devname, tail);
+			mutex_unlock(&add_del_lock);
 		} else if (0 == strcmp(arg_name, "insert")) {
 			devname = get_devname(&tail);
 			printk(KERN_INFO "nat46: insert new rule into device (%s) with '%s'\n", devname, tail);
+			mutex_lock(&add_del_lock);
 			nat46_insert(devname, tail);
+			mutex_unlock(&add_del_lock);
 		} else if (0 == strcmp(arg_name, "remove")) {
 			devname = get_devname(&tail);
 			printk(KERN_INFO "nat46: remove a rule from the device (%s) with '%s'\n", devname, tail);
+			mutex_lock(&add_del_lock);
 			nat46_remove(devname, tail);
+			mutex_unlock(&add_del_lock);
 		}
 	}
 

--- a/nat46/modules/nat46-netdev.c
+++ b/nat46/modules/nat46-netdev.c
@@ -169,6 +169,7 @@ void nat46_netdev_destroy(struct net_device *dev)
 {
 	netdev_nat46_set_instance(dev, NULL);
 	unregister_netdev(dev);
+	free_netdev(dev);
 	printk("nat46: Destroying nat46 device.\n");
 }
 


### PR DESCRIPTION
    The nat46 module crash when get create/delete/config/insert same time.
    The nat46 module can revices the applition by /proc/net/nat46/control file at the same time. So it need add the mutex lock for create/delete/config/insert nat46 devices.

    [   95.827044] <0>.(0)[1485:464xlatcfg]nat46: deleting device (464-xlatltewan)
    [   95.827251] <1>.(1)[2230:464xlatcfg]nat46: adding device (464-xlatltewan)
    [   95.827956] <0>.(0)[1485:464xlatcfg]Destroying '464-xlatltewan'
    [   95.828809] <1>.(1)[2230:464xlatcfg]Can not add: device '464-xlatltewan' already exists!
    [   95.829555] <0>.(0)[1485:464xlatcfg][nat46] release_nat46_instance: freeing nat46 instance with 1 pairs
    [   95.830577] <1>.(1)[2230:464xlatcfg]nat46: configure device (464-xlatltewan) with 'local.style NONE local.v4 192.0.0.1/32 local.v6 2001:50:55:a6:b896:3138:e9b1:ac3c/128 remote.style RFC6052 remote.v6 2002:172:903::c000:aa/96'
    [   95.834325] <1>.(1)[2230:464xlatcfg][name:fault&]Unable to handle kernel NULL pointer dereference at virtual address 000000000000000c

    [   96.982806] <1>-(1)[2230:464xlatcfg]Hardware name: MediaTek evb6890v1_64_cpe (DT)
    [   96.983752] <1>-(1)[2230:464xlatcfg]Call trace:
    [   96.984332] <1>-(1)[2230:464xlatcfg] dump_backtrace+0x0/0x150
    [   96.985061] <1>-(1)[2230:464xlatcfg] show_stack+0x24/0x30
    [   96.985748] <1>-(1)[2230:464xlatcfg] dump_stack+0x90/0xb8
    [   96.986435] <1>-(1)[2230:464xlatcfg] mrdump_common_die+0x2a0/0x2b0
    [   96.987218] <1>-(1)[2230:464xlatcfg] ipanic_die+0x38/0x44
    [   96.987904] <1>-(1)[2230:464xlatcfg] notifier_call_chain+0x70/0x90
    [   96.988688] <1>-(1)[2230:464xlatcfg] atomic_notifier_call_chain+0x3c/0x4c
    [   96.989547] <1>-(1)[2230:464xlatcfg] notify_die+0x28/0x30
    [   96.990233] <1>-(1)[2230:464xlatcfg] die+0xf4/0x294
    [   96.990853] <1>-(1)[2230:464xlatcfg] die_kernel_fault+0xa0/0xc8
    [   96.991604] <1>-(1)[2230:464xlatcfg] __do_kernel_fault+0xd8/0x100
    [   96.992376] <1>-(1)[2230:464xlatcfg] do_page_fault+0x3dc/0x3fc
    [   96.993116] <1>-(1)[2230:464xlatcfg] do_translation_fault+0x54/0x98
    [   96.993911] <1>-(1)[2230:464xlatcfg] do_mem_abort+0x6c/0x14c
    [   96.994629] <1>-(1)[2230:464xlatcfg] el1_da+0x1c/0xac
    [   96.995272] <1>-(1)[2230:464xlatcfg] nat46_set_config+0x24/0x5c [nat46]
    [   96.996111] <1>-(1)[2230:464xlatcfg] nat46_configure+0x44/0x58 [nat46]
    [   96.996940] <1>-(1)[2230:464xlatcfg] nat46_destroy_all+0x340/0x3e0 [nat46]
    [   96.997812] <1>-(1)[2230:464xlatcfg] proc_reg_write+0x7c/0xbc
    [   96.998542] <1>-(1)[2230:464xlatcfg] do_loop_readv_writev+0x7c/0xcc
    [   96.999337] <1>-(1)[2230:464xlatcfg] do_iter_write+0x100/0x11c
    [   97.000077] <1>-(1)[2230:464xlatcfg] vfs_writev+0x94/0xd8
    [   97.000762] <1>-(1)[2230:464xlatcfg] do_writev+0x68/0xc0
    [   97.001437] <1>-(1)[2230:464xlatcfg] __arm64_sys_writev+0x28/0x34
    [   97.002211] <1>-(1)[2230:464xlatcfg] el0_svc_common.constprop.0+0x94/0x114
    [   97.003082] <1>-(1)[2230:464xlatcfg] el0_svc_handler+0x44/0x78
    [   97.003821] <1>-(1)[2230:464xlatcfg] el0_svc+0x8/0xc
