### PR TITLE
Fix coverity issues observed so far

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1143,6 +1143,8 @@ static void nat46_fixup_icmp6_paramprob(nat46_instance_t *nat46, struct ipv6hdr 
         if (new_pptr >= 0) {
           icmp6h->icmp6_cksum = csum16_upd(icmp6h->icmp6_cksum, (*pptr6 & 0xffff), (new_pptr << 8));
           *pptr4 = 0xff & new_pptr;
+          update_icmp6_type_code(nat46, icmp6h, 12, 0);
+          len = xlate_payload6_to4(nat46, (icmp6h + 1), get_next_header_ptr6((icmp6h + 1), len), len, &icmp6h->icmp6_cksum, ptailTruncSize);
         } else {
           ip6h->nexthdr = NEXTHDR_NONE;
         }
@@ -1151,6 +1153,8 @@ static void nat46_fixup_icmp6_paramprob(nat46_instance_t *nat46, struct ipv6hdr 
       }
       break;
     case 1:
+      icmp6h->icmp6_cksum = csum16_upd(icmp6h->icmp6_cksum, ((*pptr6 >> 16) & 0xffff), 0);
+      icmp6h->icmp6_cksum = csum16_upd(icmp6h->icmp6_cksum, (*pptr6 & 0xffff), 0);
       *pptr6 = 0;
       update_icmp6_type_code(nat46, icmp6h, 3, 2);
       len = xlate_payload6_to4(nat46, (icmp6h + 1), get_next_header_ptr6((icmp6h + 1), len), len, &icmp6h->icmp6_cksum, ptailTruncSize);

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -715,7 +715,7 @@ __sum16 csum16_upd(__sum16 csum, u16 old, u16 new) {
 
 /* Add the TCP/UDP pseudoheader, basing on the existing checksum */
 
-__sum16 csum_tcpudp_remagic(__be32 saddr, __be32 daddr, unsigned short len,
+__sum16 csum_tcpudp_remagic(__be32 saddr, __be32 daddr, u32 len,
                   unsigned char proto, u16 csum) {
   u16 *pdata;
   u16 len0, len1;

--- a/nat46/modules/nat46-module.c
+++ b/nat46/modules/nat46-module.c
@@ -86,7 +86,7 @@ static char *get_devname(char **ptail)
 {
 	const int maxlen = IFNAMSIZ-1;
 	char *devname = get_next_arg(ptail);
-	if(strlen(devname) > maxlen) {
+	if(devname && (strlen(devname) > maxlen)) {
 		printk(KERN_INFO "nat46: '%s' is "
 			"longer than %d chars, truncating\n", devname, maxlen);
 		devname[maxlen] = 0;

--- a/nat46/modules/nat46-netdev.c
+++ b/nat46/modules/nat46-netdev.c
@@ -167,6 +167,8 @@ err:
 
 void nat46_netdev_destroy(struct net_device *dev)
 {
+	dev->flags &= ~IFF_UP;
+	netif_stop_queue(dev);
 	netdev_nat46_set_instance(dev, NULL);
 	unregister_netdev(dev);
 	free_netdev(dev);


### PR DESCRIPTION
nat46-core: silence coverity warning of result_independent_of_operands
nat46-module: avoid dereferencing a NULL pointer