### PR TITLE
add a module argument to ignore TOS translate for IPv4

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1833,9 +1833,9 @@ void nat46_ipv4_input(struct sk_buff *old_skb) {
 #endif
 
   /* expand header (add 20 extra bytes at the beginning of sk_buff) */
-  pskb_expand_head(new_skb, IPV6V4HDRDELTA + (add_frag_header?8:0), 0, GFP_ATOMIC);
+  pskb_expand_head(new_skb, IPV6HDRSIZE - (hdr4->ihl << 2) + (add_frag_header?8:0), 0, GFP_ATOMIC);
 
-  skb_push(new_skb, IPV6V4HDRDELTA + (add_frag_header?8:0)); /* push boundary by extra 20 bytes */
+  skb_push(new_skb, IPV6HDRSIZE - (hdr4->ihl << 2) + (add_frag_header?8:0)); /* push boundary by extra 20 bytes */
 
   skb_reset_network_header(new_skb);
   skb_set_transport_header(new_skb, IPV6HDRSIZE + (add_frag_header?8:0) ); /* transport (TCP/UDP/ICMP/...) header starts after 40 bytes */
@@ -1848,7 +1848,7 @@ void nat46_ipv4_input(struct sk_buff *old_skb) {
   *(__be32 *)hdr6 = htonl(0x60000000 | (tclass << 20)) | flowlabel; /* version, priority, flowlabel */
 
   /* IPv6 length is a payload length, IPv4 is hdr+payload */
-  hdr6->payload_len = htons(ntohs(hdr4->tot_len) - sizeof(struct iphdr) + (add_frag_header?8:0));
+  hdr6->payload_len = htons(ntohs(hdr4->tot_len) - (hdr4->ihl << 2) + (add_frag_header?8:0));
   hdr6->nexthdr = hdr4->protocol;
   hdr6->hop_limit = hdr4->ttl;
   memcpy(&hdr6->saddr, v6saddr, 16);

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1143,6 +1143,8 @@ static void nat46_fixup_icmp6_paramprob(nat46_instance_t *nat46, struct ipv6hdr 
         if (new_pptr >= 0) {
           icmp6h->icmp6_cksum = csum16_upd(icmp6h->icmp6_cksum, (*pptr6 & 0xffff), (new_pptr << 8));
           *pptr4 = 0xff & new_pptr;
+          update_icmp6_type_code(nat46, icmp6h, 12, 0);
+          len = xlate_payload6_to4(nat46, (icmp6h + 1), get_next_header_ptr6((icmp6h + 1), len), len, &icmp6h->icmp6_cksum, ptailTruncSize);
         } else {
           ip6h->nexthdr = NEXTHDR_NONE;
         }
@@ -1151,6 +1153,8 @@ static void nat46_fixup_icmp6_paramprob(nat46_instance_t *nat46, struct ipv6hdr 
       }
       break;
     case 1:
+      icmp6h->icmp6_cksum = csum16_upd(icmp6h->icmp6_cksum, ((*pptr6 >> 16) & 0xffff), 0);
+      icmp6h->icmp6_cksum = csum16_upd(icmp6h->icmp6_cksum, (*pptr6 & 0xffff), 0);
       *pptr6 = 0;
       update_icmp6_type_code(nat46, icmp6h, 3, 2);
       len = xlate_payload6_to4(nat46, (icmp6h + 1), get_next_header_ptr6((icmp6h + 1), len), len, &icmp6h->icmp6_cksum, ptailTruncSize);

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1844,7 +1844,7 @@ void nat46_ipv4_input(struct sk_buff *old_skb) {
   memset(hdr6, 0, sizeof(*hdr6) + (add_frag_header?8:0));
 
   /* build IPv6 header */
-  tclass = 0; /* traffic class */
+  tclass = ip_tos_ignore ? 0 : hdr4->tos; /* traffic class */
   *(__be32 *)hdr6 = htonl(0x60000000 | (tclass << 20)) | flowlabel; /* version, priority, flowlabel */
 
   /* IPv6 length is a payload length, IPv4 is hdr+payload */

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1824,7 +1824,7 @@ void nat46_ipv4_input(struct sk_buff *old_skb) {
   }
 
   /* Remove any debris in the socket control block */
-  memset(IPCB(new_skb), 0, sizeof(struct inet_skb_parm));
+  memset(IP6CB(new_skb), 0, sizeof(struct inet6_skb_parm));
   /* Remove netfilter references to IPv4 packet, new netfilter references will be created based on IPv6 packet */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0)
   nf_reset(new_skb);
@@ -1870,7 +1870,7 @@ void nat46_ipv4_input(struct sk_buff *old_skb) {
   // FIXME: check if you can not fit the packet into the cached MTU
   // if (dst_mtu(skb_dst(new_skb))==0) { }
 
-  nat46debug(5, "about to send v6 packet, flags: %02x",  IPCB(new_skb)->flags);
+  nat46debug(5, "about to send v6 packet, flags: %02x",  IP6CB(new_skb)->flags);
   nat46_netdev_count_xmit(new_skb, old_skb->dev);
   netif_rx(new_skb);
 

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -715,7 +715,7 @@ __sum16 csum16_upd(__sum16 csum, u16 old, u16 new) {
 
 /* Add the TCP/UDP pseudoheader, basing on the existing checksum */
 
-__sum16 csum_tcpudp_remagic(__be32 saddr, __be32 daddr, unsigned short len,
+__sum16 csum_tcpudp_remagic(__be32 saddr, __be32 daddr, u32 len,
                   unsigned char proto, u16 csum) {
   u16 *pdata;
   u16 len0, len1;

--- a/nat46/modules/nat46-module.c
+++ b/nat46/modules/nat46-module.c
@@ -57,12 +57,16 @@ MODULE_DESCRIPTION("NAT46 stateless translation");
 
 int debug = 0;
 int zero_csum_pass = 0;
+int ip_tos_ignore = 0;
 
 module_param(debug, int, 0);
-MODULE_PARM_DESC(debug, "debugging messages level (default=1)");
+MODULE_PARM_DESC(debug, "debugging messages level (default=0)");
 
 module_param(zero_csum_pass, int, 0);
 MODULE_PARM_DESC(zero_csum_pass, "pass all-zero checksum unchanged (default=0)");
+
+module_param(ip_tos_ignore, int, 0);
+MODULE_PARM_DESC(ip_tos_ignore, "ignore IPv4 TOS and set IPv6 traffic class to zero (default=0)");
 
 static DEFINE_MUTEX(add_del_lock);
 

--- a/nat46/modules/nat46-module.c
+++ b/nat46/modules/nat46-module.c
@@ -86,7 +86,7 @@ static char *get_devname(char **ptail)
 {
 	const int maxlen = IFNAMSIZ-1;
 	char *devname = get_next_arg(ptail);
-	if(strlen(devname) > maxlen) {
+	if(devname && (strlen(devname) > maxlen)) {
 		printk(KERN_INFO "nat46: '%s' is "
 			"longer than %d chars, truncating\n", devname, maxlen);
 		devname[maxlen] = 0;

--- a/nat46/modules/nat46-module.h
+++ b/nat46/modules/nat46-module.h
@@ -15,3 +15,4 @@
 
 extern int debug;
 extern int zero_csum_pass;
+extern int ip_tos_ignore;

--- a/nat46/modules/nat46-netdev.c
+++ b/nat46/modules/nat46-netdev.c
@@ -167,6 +167,8 @@ err:
 
 void nat46_netdev_destroy(struct net_device *dev)
 {
+	dev->flags &= ~IFF_UP;
+	netif_stop_queue(dev);
 	netdev_nat46_set_instance(dev, NULL);
 	unregister_netdev(dev);
 	free_netdev(dev);


### PR DESCRIPTION
RFC 7915 Section 4.1: Translating IPv4 Headers into IPv6 Headers

Traffic Class:  By default, copied from the IP Type Of Service (TOS)
   octet.  According to [RFC2474], the semantics of the bits are
   identical in IPv4 and IPv6.  However, in some IPv4 environments
   these fields might be used with the old semantics of "Type Of
   Service and Precedence".  An implementation of a translator SHOULD
   support an administratively configurable option to ignore the IPv4
   TOS and always set the IPv6 traffic class (TC) to zero.  In
   addition, if the translator is at an administrative boundary, the
   filtering and update considerations of [RFC2475] may be
   applicable.