### PR TITLE
Add compiling on push/PR

### DIFF
--- a/.github/workflows/c-compile.yml
+++ b/.github/workflows/c-compile.yml
@@ -1,7 +1,7 @@
 on:
-  # push
-  # pull_request
-  workflow_dispatch
+  - push
+  - pull_request
+  - workflow_dispatch
 
 name: C/C++ CI prototype
   

--- a/.github/workflows/c-compile.yml
+++ b/.github/workflows/c-compile.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: build the NAT46 module
       run: |
         cd nat46/modules


### PR DESCRIPTION
As a token favor to the times, add at least compiling of the module. This is hard to call "CI", but at least it is something. Gradually it might (and should) be extended.