### PR TITLE
nat46-module: fix modpost warning

### DIFF
--- a/nat46/modules/nat46-module.c
+++ b/nat46/modules/nat46-module.c
@@ -240,7 +240,7 @@ static void __net_exit nat46_ns_exit(struct net *net)
 	}
 }
 
-static struct pernet_operations nat46_netops = {
+static struct pernet_operations nat46_net_ops = {
   .init = nat46_ns_init,
   .exit = nat46_ns_exit,
   .id = &nat46_netid,
@@ -252,7 +252,7 @@ static int __init nat46_init(void)
 	int ret = 0;
 
 	printk("nat46: module (version %s) loaded.\n", NAT46_VERSION);
-	ret = register_pernet_subsys(&nat46_netops);
+	ret = register_pernet_subsys(&nat46_net_ops);
 	if(ret) {
 		goto error;
 	}
@@ -264,7 +264,7 @@ error:
 
 static void __exit nat46_exit(void)
 {
-	unregister_pernet_subsys(&nat46_netops);
+	unregister_pernet_subsys(&nat46_net_ops);
 	printk("nat46: module unloaded.\n");
 }
 


### PR DESCRIPTION
WARNING: modpost: nat46.o(.data+0x30): Section mismatch in reference from the variable nat46_netops to the function .init.text:nat46_ns_init() The variable nat46_netops references
the function __init nat46_ns_init()
If the reference is valid then annotate the
variable with __init* or __refdata (see linux/init.h) or name the variable: *_template, *_timer, *_sht, *_ops, *_probe, *_probe_one, *_console