### PR TITLE
Fix crash when viewing nat46 kernel module config

### DIFF
--- a/nat46/modules/nat46-module.c
+++ b/nat46/modules/nat46-module.c
@@ -94,7 +94,7 @@ static int nat46_proc_show(struct seq_file *m, void *v)
 {
 	struct net *net;
 
-	net = (struct net *)v;
+	net = (struct net *)m->private;
 	nat64_show_all_configs(net, m);
 	return 0;
 }


### PR DESCRIPTION
In the commit
91b8e68 Add network namespace awareness to nat46
the network namespace of the /proc/net file is now passed via single_open() to nat46_proc_show(). However, the priv arg passed to single_open() is accessed via the seq_file, not the second value.
When using the second value, the 'network namespace' is invalid and causes a kernel oops.

Access the network namespace in nat46_proc_show from struct seq_file.