### PR TITLE
Zero checksum handling for UDP4->UDP6

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1766,6 +1766,11 @@ void ip6_update_csum(struct sk_buff * skb, struct ipv6hdr * ip6hdr, int do_atomi
       struct udphdr *udp = udp_hdr(skb);
       unsigned udplen = ntohs(ip6hdr->payload_len) - (do_atomic_frag?8:0); /* UDP hdr + payload */
 
+      if ((udp->check == 0) && zero_csum_pass) {
+         /* zero checksum and the config to pass it is set - do nothing with it */
+         break;
+      }
+
       oldsum = udp->check;
       udp->check = 0;
 

--- a/nat46/modules/nat46-module.c
+++ b/nat46/modules/nat46-module.c
@@ -240,7 +240,7 @@ static void __net_exit nat46_ns_exit(struct net *net)
 	}
 }
 
-static struct pernet_operations nat46_netops = {
+static struct pernet_operations nat46_net_ops = {
   .init = nat46_ns_init,
   .exit = nat46_ns_exit,
   .id = &nat46_netid,
@@ -252,7 +252,7 @@ static int __init nat46_init(void)
 	int ret = 0;
 
 	printk("nat46: module (version %s) loaded.\n", NAT46_VERSION);
-	ret = register_pernet_subsys(&nat46_netops);
+	ret = register_pernet_subsys(&nat46_net_ops);
 	if(ret) {
 		goto error;
 	}
@@ -264,7 +264,7 @@ error:
 
 static void __exit nat46_exit(void)
 {
-	unregister_pernet_subsys(&nat46_netops);
+	unregister_pernet_subsys(&nat46_net_ops);
 	printk("nat46: module unloaded.\n");
 }
 


### PR DESCRIPTION
MAP should be transparent to the UDP csum zero in both directions.