### PR TITLE
nat46-core: Fix FIXMEs about ICMPv6 parameter pointers

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1368,6 +1368,7 @@ static uint16_t nat46_fixup_icmp_parameterprob(nat46_instance_t *nat46, struct i
    */
   static int ptr4_6[] = { 0, 1, 4, 4, -1, -1, -1, -1, 7, 6, -1, -1, 8, 8, 8, 8, 24, 24, 24, 24, -1 };
   u8 *icmp_pptr = icmp_parameter_ptr(icmph);
+  u32 *icmp6_pptr = icmp6_parameter_ptr((struct icmp6hdr *)icmph);
   int new_pptr = -1;
   switch (icmph->code) {
     case 0:
@@ -1376,7 +1377,7 @@ static uint16_t nat46_fixup_icmp_parameterprob(nat46_instance_t *nat46, struct i
         icmph->code = 0;
         new_pptr = ptr4_6[*icmp_pptr];
         if(new_pptr >= 0) {
-          /* FIXME: update the parameter pointer in ICMPv6 with new_pptr value */
+          *icmp6_pptr = htonl(new_pptr);
         }
       } else {
         iph->protocol = NEXTHDR_NONE;
@@ -1449,6 +1450,7 @@ static uint16_t nat46_fixup_icmp_dest_unreach(nat46_instance_t *nat46, struct ip
    *
    */
 
+  u32 *pptr6 = icmp6_parameter_ptr((struct icmp6hdr *)icmph);
   u16 *pmtu = ((u16 *)icmph) + 3; /* IPv4-compatible MTU value is 16 bit */
 
   switch (icmph->code) {
@@ -1457,9 +1459,9 @@ static uint16_t nat46_fixup_icmp_dest_unreach(nat46_instance_t *nat46, struct ip
       icmph->code = 0;
       break;
     case 2:
-      /* FIXME: set ICMPv6 parameter pointer to 6 */
       icmph->type = 4;
       icmph->code = 1;
+      *pptr6 = htonl(6);
       break;
     case 3:
       icmph->code = 4;


### PR DESCRIPTION
1 - Update the parameter pointer in ICMPv6 with new_pptr value
    (nat46_fixup_icmp_parameterprob)

2 - Set ICMPv6 parameter pointer to 6 (nat46_fixup_icmp_dest_unreach)