### PR TITLE
README: remove pre-merge instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,8 @@ This is an OpenWRT feed with a Linux kernel module implementing flexible NAT46.
 Compiling
 =========
 
-With Barrier Breaker (trunk), add the following line to *feeds.conf.default*:
-```
-src-git nat46 https://github.com/ayourtch/nat46.git
-```
-
-then issue:
-
-```
-./scripts/feeds update -a
-./scripts/feeds install -a -p nat46
-```
-
-This will cause the following to appear in the "make menuconfig":
+Since [4856fa3](https://github.com/openwrt/openwrt/commit/4856fa30a6c6b6fca5e036a226e3e4658105d9c7)
+was merged, nat46 can be built by selecting the corresponding option under:
 
  * Kernel modules -> Network Support -> kmod-nat46
 


### PR DESCRIPTION
Since 2019, this has been mainlined.