### PR TITLE
Add skb length check before L4 header access in nat46_ipv4/6_input

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1825,6 +1825,10 @@ static int ip4_input_not_interested(nat46_instance_t *nat46, struct iphdr *iph, 
     nat46debug(3, "Not an IPv4 packet");
     return 1;
   }
+  if (old_skb->len < sizeof(struct iphdr) || old_skb->len < ntohs(iph->tot_len) || (iph->ihl << 2) < sizeof(struct iphdr) || iph->version != 4) {
+    nat46debug(3, "Invalid IPv4 packet or truncated payload: %d", old_skb->len);
+    return 1;
+  }
   // FIXME: check source to be within our prefix
   return 0;
 }
@@ -1880,6 +1884,8 @@ int nat46_ipv4_input(struct sk_buff *old_skb) {
   int check_for_l4 = 0;
   int having_l4 = 0;
   int add_frag_header = 0;
+  int v4packet_l3size = 0;
+  int l4_payload_len = 0;
 
   struct ipv6hdr * hdr6;
   struct iphdr * hdr4 = ip_hdr(old_skb);
@@ -1897,6 +1903,8 @@ int nat46_ipv4_input(struct sk_buff *old_skb) {
   }
   nat46debug(1, "nat46_ipv4_input packet");
   nat46debug(5, "nat46_ipv4_input protocol: %d, len: %d, flags: %02x", hdr4->protocol, old_skb->len, IPCB(old_skb)->flags);
+  v4packet_l3size = hdr4->ihl << 2;
+  l4_payload_len = ntohs(hdr4->tot_len) - v4packet_l3size;
   if(0 == (ntohs(hdr4->frag_off) & 0x3FFF) ) {
     check_for_l4 = 1;
   } else if (IPPROTO_ICMP == hdr4->protocol) {
@@ -1909,6 +1917,8 @@ int nat46_ipv4_input(struct sk_buff *old_skb) {
       goto done;
     }
     hdr4 = ip_hdr(old_skb);
+    v4packet_l3size = hdr4->ihl << 2;
+    l4_payload_len = ntohs(hdr4->tot_len) - v4packet_l3size;
     check_for_l4 = 1;
   } else {
     add_frag_header = 1;
@@ -1920,23 +1930,39 @@ int nat46_ipv4_input(struct sk_buff *old_skb) {
   if (check_for_l4) {
     switch(hdr4->protocol) {
       case IPPROTO_TCP: {
-	struct tcphdr *th = tcp_hdr(old_skb);
+	struct tcphdr *th;
+	if ((l4_payload_len < sizeof(*th)) || (old_skb->len < v4packet_l3size + sizeof(*th))) {
+	  nat46debug(0, "[nat46] Len short for v4 TCP header");
+	  goto done;
+	}
+	th = tcp_hdr(old_skb);
 	sport = th->source;
 	dport = th->dest;
 	having_l4 = 1;
 	break;
 	}
       case IPPROTO_UDP: {
-	struct udphdr *udp = udp_hdr(old_skb);
+	struct udphdr *udp;
+	if ((l4_payload_len < sizeof(*udp)) || (old_skb->len < v4packet_l3size + sizeof(*udp))) {
+	  nat46debug(0, "[nat46] Len short for v4 UDP header");
+	  goto done;
+	}
+	udp = udp_hdr(old_skb);
 	sport = udp->source;
 	dport = udp->dest;
 	having_l4 = 1;
 	break;
 	}
-      case IPPROTO_ICMP:
+      case IPPROTO_ICMP: {
+	struct icmphdr *icmph;
+	if ((l4_payload_len < sizeof(*icmph)) || (old_skb->len < v4packet_l3size + sizeof(*icmph))) {
+	  nat46debug(0, "[nat46] Len short for ICMPv4 header");
+	  goto done;
+	}
 	sport = dport = nat46_fixup_icmp(nat46, hdr4, old_skb);
 	having_l4 = 1;
 	break;
+	}
       default:
 	break;
     }
@@ -1971,9 +1997,9 @@ int nat46_ipv4_input(struct sk_buff *old_skb) {
 #endif
 
   /* expand header (add 20 extra bytes at the beginning of sk_buff) */
-  pskb_expand_head(new_skb, IPV6HDRSIZE - (hdr4->ihl << 2) + (add_frag_header?8:0), 0, GFP_ATOMIC);
+  pskb_expand_head(new_skb, IPV6HDRSIZE - v4packet_l3size + (add_frag_header?8:0), 0, GFP_ATOMIC);
 
-  skb_push(new_skb, IPV6HDRSIZE - (hdr4->ihl << 2) + (add_frag_header?8:0)); /* push boundary by extra 20 bytes */
+  skb_push(new_skb, IPV6HDRSIZE - v4packet_l3size + (add_frag_header?8:0)); /* push boundary by extra 20 bytes */
 
   skb_reset_network_header(new_skb);
   skb_set_transport_header(new_skb, IPV6HDRSIZE + (add_frag_header?8:0) ); /* transport (TCP/UDP/ICMP/...) header starts after 40 bytes */
@@ -1986,7 +2012,7 @@ int nat46_ipv4_input(struct sk_buff *old_skb) {
   *(__be32 *)hdr6 = htonl(0x60000000 | (tclass << 20)) | flowlabel; /* version, priority, flowlabel */
 
   /* IPv6 length is a payload length, IPv4 is hdr+payload */
-  hdr6->payload_len = htons(ntohs(hdr4->tot_len) - (hdr4->ihl << 2) + (add_frag_header?8:0));
+  hdr6->payload_len = htons(l4_payload_len + (add_frag_header?8:0));
   hdr6->nexthdr = hdr4->protocol;
   hdr6->hop_limit = hdr4->ttl;
   memcpy(&hdr6->saddr, v6saddr, 16);

--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -1304,8 +1304,8 @@ static int ip6_input_not_interested(nat46_instance_t *nat46, struct ipv6hdr *ip6
     nat46debug(3, "Not an IPv6 packet");
     return 1;
   }
-  if(old_skb->len < sizeof(struct ipv6hdr) || ip6h->version != 6) {
-    nat46debug(3, "Len short or not correct version: %d", ip6h->version);
+  if(old_skb->len < sizeof(struct ipv6hdr) || old_skb->len < ntohs(ip6h->payload_len) + sizeof(struct ipv6hdr) || ip6h->version != 6) {
+    nat46debug(3, "Invalid IPv6 packet or truncated payload: %d", old_skb->len);
     return 1;
   }
   if (!(ipv6_addr_type(&ip6h->saddr) & IPV6_ADDR_UNICAST)) {
@@ -1613,7 +1613,7 @@ int nat46_ipv6_input(struct sk_buff *old_skb) {
   int truncSize = 0;
   int tailTruncSize = 0;
   int v6packet_l3size = sizeof(*ip6h);
-  int l3_infrag_payload_len = ntohs(ip6h->payload_len);
+  int l3_infrag_payload_len = 0;
   int check_for_l4 = 0;
 
   if (!nat46) {
@@ -1628,9 +1628,17 @@ int nat46_ipv6_input(struct sk_buff *old_skb) {
   }
   nat46debug(5, "nat46_ipv6_input next hdr: %d, len: %d, is_fragment: %d",
                 ip6h->nexthdr, old_skb->len, ip6h->nexthdr == NEXTHDR_FRAGMENT);
+  l3_infrag_payload_len = ntohs(ip6h->payload_len);
   proto = ip6h->nexthdr;
   if (proto == NEXTHDR_FRAGMENT) {
-    struct frag_hdr *fh = (struct frag_hdr*)(ip6h + 1);
+    struct frag_hdr *fh;
+
+    if ((l3_infrag_payload_len < sizeof(struct frag_hdr)) || (old_skb->len < v6packet_l3size + sizeof(struct frag_hdr))) {
+      nat46debug(0, "[nat46] Len short for Fragment header");
+      goto done;
+    }
+
+    fh = (struct frag_hdr*)(ip6h + 1);
     v6packet_l3size += sizeof(struct frag_hdr);
     l3_infrag_payload_len -= sizeof(struct frag_hdr);
     nat46debug(2, "Fragment ID: %08X", fh->identification);
@@ -1685,15 +1693,26 @@ int nat46_ipv6_input(struct sk_buff *old_skb) {
     switch(proto) {
       /* CHECKSUMS UPDATE */
       case NEXTHDR_TCP: {
-        struct tcphdr *th = add_offset(ip6h, v6packet_l3size);
-        u16 sum1 = csum_ipv6_unmagic(nat46, &ip6h->saddr, &ip6h->daddr, l3_infrag_payload_len, NEXTHDR_TCP, th->check);
-        u16 sum2 = csum_tcpudp_remagic(v4saddr, v4daddr, l3_infrag_payload_len, NEXTHDR_TCP, sum1);
+        struct tcphdr *th;
+        u16 sum1, sum2;
+        if ((l3_infrag_payload_len < sizeof(*th)) || (old_skb->len < v6packet_l3size + sizeof(*th))) {
+          nat46debug(0, "[nat46] Len short for v6 TCP header");
+          goto done;
+        }
+        th = add_offset(ip6h, v6packet_l3size);
+        sum1 = csum_ipv6_unmagic(nat46, &ip6h->saddr, &ip6h->daddr, l3_infrag_payload_len, NEXTHDR_TCP, th->check);
+        sum2 = csum_tcpudp_remagic(v4saddr, v4daddr, l3_infrag_payload_len, NEXTHDR_TCP, sum1);
         th->check = sum2;
         break;
         }
       case NEXTHDR_UDP: {
-        struct udphdr *udp = add_offset(ip6h, v6packet_l3size);
+        struct udphdr *udp;
         u16 sum1, sum2;
+        if ((l3_infrag_payload_len < sizeof(*udp)) || (old_skb->len < v6packet_l3size + sizeof(*udp))) {
+          nat46debug(0, "[nat46] Len short for v6 UDP header");
+          goto done;
+        }
+        udp = add_offset(ip6h, v6packet_l3size);
         if ((udp->check == 0) && zero_csum_pass) {
           /* zero checksum and the config to pass it is set - do nothing with it */
           break;
@@ -1704,8 +1723,14 @@ int nat46_ipv6_input(struct sk_buff *old_skb) {
         break;
         }
       case NEXTHDR_ICMP: {
-        struct icmp6hdr *icmp6h = add_offset(ip6h, v6packet_l3size);
-        u16 sum1 = csum_ipv6_unmagic(nat46, &ip6h->saddr, &ip6h->daddr, l3_infrag_payload_len, NEXTHDR_ICMP, icmp6h->icmp6_cksum);
+        struct icmp6hdr *icmp6h;
+        u16 sum1;
+        if ((l3_infrag_payload_len < sizeof(*icmp6h)) || (old_skb->len < v6packet_l3size + sizeof(*icmp6h))) {
+          nat46debug(0, "[nat46] Len short for ICMPv6 header");
+          goto done;
+        }
+        icmp6h = add_offset(ip6h, v6packet_l3size);
+        sum1 = csum_ipv6_unmagic(nat46, &ip6h->saddr, &ip6h->daddr, l3_infrag_payload_len, NEXTHDR_ICMP, icmp6h->icmp6_cksum);
         icmp6h->icmp6_cksum = sum1;
         nat46debug_dump(nat46, 10, icmp6h, l3_infrag_payload_len);
         nat46_fixup_icmp6(nat46, ip6h, icmp6h, old_skb, &tailTruncSize);


### PR DESCRIPTION
1. A LAN IPv4 packet whose `tot_len`/skb length is shorter than the IPv4 header or the subsequent TCP/UDP/ICMP header still has its L4 header fields dereferenced (and in the case of ICMP, modified in-place). This is an OOB read+write of up to 32 bytes past the skb data on the MAP-T LAN ingress path.

2. A WAN IPv6 packet whose `payload_len`/skb length is shorter than a TCP/UDP/ICMPv6 header still has its L4 header dereferenced and written (checksum field), and (for fragments) its frag_hdr dereferenced. This is an OOB read+write of up to 18 bytes past the skb data on the MAP-T WAN ingress path.
