### PR TITLE
nat46-core: Add bounds checking for v6_pref_len/v4_pref_len/ea_len/psid_offset during rule parsing

### DIFF
--- a/nat46/modules/nat46-core.c
+++ b/nat46/modules/nat46-core.c
@@ -129,6 +129,9 @@ static int try_parse_ipv6_prefix(struct in6_addr *pref, int *pref_len, char *arg
     *arg_plen++ = 0;
     if (pref_len) {
       *pref_len = simple_strtol(arg_plen, NULL, 10);
+      if ((*pref_len < 0) || (*pref_len > 128)) {
+        return -1;
+      }
     }
   }
   err = (1 != in6_pton(arg, -1, (u8 *)pref, '\0', NULL));
@@ -142,6 +145,9 @@ static int try_parse_ipv4_prefix(u32 *v4addr, int *pref_len, char *arg) {
     *arg_plen++ = 0;
     if (pref_len) {
       *pref_len = simple_strtol(arg_plen, NULL, 10);
+      if ((*pref_len < 0) || (*pref_len > 32)) {
+        return -1;
+      }
     }
   }
   err = (1 != in4_pton(arg, -1, (u8 *)v4addr, '/', NULL));
@@ -166,8 +172,14 @@ static int try_parse_rule_arg(nat46_xlate_rule_t *rule, char *arg_name, char **p
     err = try_parse_ipv4_prefix(&rule->v4_pref, &rule->v4_pref_len, val);
   } else if (0 == strcmp(arg_name, "ea-len")) {
     rule->ea_len = simple_strtol(val, NULL, 10);
+    if ((rule->ea_len < 0) || (rule->ea_len > 48)) {
+      err = -1;
+    }
   } else if (0 == strcmp(arg_name, "psid-offset")) {
     rule->psid_offset = simple_strtol(val, NULL, 10);
+    if ((rule->psid_offset < 0) || (rule->psid_offset > 16)) {
+      err = -1;
+    }
   } else if (0 == strcmp(arg_name, "style")) {
     if (0 == strcmp("MAP", val)) {
       rule->style = NAT46_XLATE_MAP;


### PR DESCRIPTION
Configuring a nat46 instance via /proc/net/nat46/control with out-of-range prefix lengths or parameters (v6_pref_len > 128, v4_pref_len > 32, ea_len > 48, psid_offset > 16, or negative values) allowed invalid translation rules to be installed. Subsequent packet processing in xlate_map_* used these unbounded lengths in bitarray_copy(), leading to out-of-bounds writes and kernel stack memory corruption.